### PR TITLE
Preventing NPE when right-clicking on a project that does not have nbproject/project.properties

### DIFF
--- a/tikione-jacocoverage-plugin/src/fr/tikione/jacocoverage/plugin/RunProjectWithJaCoCoAction.java
+++ b/tikione-jacocoverage-plugin/src/fr/tikione/jacocoverage/plugin/RunProjectWithJaCoCoAction.java
@@ -3,6 +3,7 @@ package fr.tikione.jacocoverage.plugin;
 import fr.tikione.jacocoverage.plugin.config.Globals;
 import java.awt.event.ActionEvent;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -66,13 +67,24 @@ public final class RunProjectWithJaCoCoAction extends AbstractAction implements 
             putValue(SMALL_ICON, ImageUtilities.loadImageIcon(Globals.RUN_ICON, false));
             FileObject prjPropsFo = getProject().getProjectDirectory().getFileObject("nbproject/project.properties");
             final Properties prjProps = new Properties();
+            InputStream ins = null;
             try {
-                prjProps.load(prjPropsFo.getInputStream());
+                if (prjPropsFo != null) {
+                    prjProps.load(ins = prjPropsFo.getInputStream());
+                }
                 if (prjProps.getProperty("main.class", "").isEmpty()) {
                     setEnabled(false);
                 }
             } catch (IOException ex) {
                 Exceptions.printStackTrace(ex);
+            } finally {
+                try {
+                    if (ins != null) {
+                        ins.close();
+                    }
+                } catch (IOException ex) {
+                    Exceptions.printStackTrace(ex);
+                }
             }
         }
 


### PR DESCRIPTION
A NPE is thrown when rightclicking on a project that does not have nbproject/project.properties:
java.lang.NullPointerException
at fr.tikione.jacocoverage.plugin.RunProjectWithJaCoCoAction$ContextAction.<init>(RunProjectWithJaCoCoAction.java:70)
at fr.tikione.jacocoverage.plugin.RunProjectWithJaCoCoAction.createContextAwareInstance(RunProjectWithJaCoCoAction.java:48)
[snip]

This commit prevents that, and also ensures the stream is closed after reading the properties.

BTW, this is more a hotfix - reading from disk in context action's constructor is not very good: this constructor runs (AFAIK) in the AWT thread, and so if the properties will be on a slow filesystem, the whole UI will be blocked (and one should ideally not read the properties anyway). Not sure offhand what would be a better solution, though.
